### PR TITLE
Upgrade for compatibility with Laravel 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ should match the Laravel version.
 
 | Laravel Version | Package Version |
 |:---------------:|:---------------:|
+|       7.0       |      ^7.0       |
 |       6.0       |      ^6.0       |
 |       5.*       |      ^0.9       |
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "cviebrock/laravel-mangopay",
+  "name": "philipstyles-thc/laravel-mangopay",
   "description": "Laravel/Lumen wrapper for the office Mangopay SDK library",
   "keywords": [
     "laravel",
@@ -16,12 +16,12 @@
   "license": "MIT",
   "require": {
     "php": "^7.2",
-    "illuminate/support": "^6.0",
+    "illuminate/support": "^7.0",
     "mangopay/php-sdk-v2": "^2.4"
   },
   "require-dev": {
     "limedeck/phpunit-detailed-printer": "^5.0",
-    "orchestra/testbench": "4.*",
+    "orchestra/testbench": "5.*",
     "phpunit/phpunit": "^8.0"
   },
   "autoload": {


### PR DESCRIPTION
Simple update of two dependencies appears to be sufficient for Laravel 7.
(composer.json > name needed changing for us to pull into our host apps and test, so switch back and squash if you're happy to integrate)