### PR TITLE
Bump up version to support laravel 9

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 8
 :minor: 0
-:patch: 1
+:patch: 2
 :special: ''
 :metadata: ''

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
   "license": "MIT",
   "require": {
     "php": "^7.3|^8.0",
-    "illuminate/support": "^8",
-    "mangopay/php-sdk-v2": "^3.1"
+    "illuminate/support": "^9",
+    "mangopay/php-sdk-v2": "^3.15"
   },
   "require-dev": {
     "limedeck/phpunit-detailed-printer": "^6.0",


### PR DESCRIPTION
Bumped up the version for illuminate and mangopay php sdk.

I tested adding mango users, credit cards, bank accounts, payins, transfers, payouts, kyc documents. Seems to be all and well.